### PR TITLE
Updated the swear filter to privately message you with the offending word

### DIFF
--- a/src/pieces/blacklist.ts
+++ b/src/pieces/blacklist.ts
@@ -120,7 +120,7 @@ async function filterMessages(msg: Message): Promise<Message | void> {
 		|| finalMessage.includes(word) || finalMessagenoSpaces.includes(word)) {
 			msg.delete();
 
-			return msg.author.send(`You used the restricted word "${word}". Please refrain from doing so again.`)
+			return msg.author.send(`Your message contains the restricted word "${word}". Please refrain from using restricted words again.\n\nOriginal message:\n${msg.content}`)
 				.catch(() => msg.channel.send(`${msg.member}, you used a restricted word. Please refrain from doing so again.`));
 		}
 	}

--- a/src/pieces/blacklist.ts
+++ b/src/pieces/blacklist.ts
@@ -97,6 +97,9 @@ async function register(bot: Client): Promise<void> {
 async function filterMessages(msg: Message): Promise<Message | void> {
 	let normalizedMessage = msg.content.normalize('NFKD');
 	let selfNormalizedMessage = normalizedMessage; // Thanks, Rowan :D
+	// Distinguish between NFKD normalisation and self-normalisation to allow the original message to be
+	// normalized and sent to the offending user, without removing the spaces.
+
 	for (const [re, rep] of NORMALIZE) {
 		selfNormalizedMessage = selfNormalizedMessage.replace(re, rep);
 	}

--- a/src/pieces/blacklist.ts
+++ b/src/pieces/blacklist.ts
@@ -96,29 +96,32 @@ async function register(bot: Client): Promise<void> {
 
 async function filterMessages(msg: Message): Promise<Message | void> {
 	let normalizedMessage = msg.content.normalize('NFKD');
+	let selfNormalizedMessage = normalizedMessage; // Thanks, Rowan :D
 	for (const [re, rep] of NORMALIZE) {
-		const cleanerString = normalizedMessage.replace(re, rep);
-		normalizedMessage = cleanerString;
+		selfNormalizedMessage = selfNormalizedMessage.replace(re, rep);
 	}
 
-	const cleanNormalizedMessage = normalizedMessage.replace(CLEANER, '');
+	const cleanSelfNormalizedMessage = selfNormalizedMessage.replace(CLEANER, '');
 	const cleanMessage = msg.content.replace(CLEANER, '');
 
 	const lowercaseMessage = msg.content.toLowerCase();
 	const cleanLowercaseMessage = cleanMessage.toLowerCase();
-	const cleanNormalizedLowercaseMessage = cleanNormalizedMessage.toLowerCase();
+	const cleanSelfNormalizedLowercaseMessage = cleanSelfNormalizedMessage.toLowerCase();
 
 	// strip of any special characters and spaces
-	const finalMessage = cleanNormalizedLowercaseMessage.replace(/[^a-zA-Z0-9 ]/g, '');
+	const finalMessage = cleanSelfNormalizedLowercaseMessage.replace(/[^a-zA-Z0-9 ]/g, '');
 	const finalMessagenoSpaces = finalMessage.replace(/\s/g, '');
 
 	for (const word of BLACKLIST) {
 		const simpleContains = lowercaseMessage.includes(word);
-		if (simpleContains || cleanLowercaseMessage.includes(word) || cleanNormalizedLowercaseMessage.includes(word)
+		if (simpleContains || cleanLowercaseMessage.includes(word) || cleanSelfNormalizedLowercaseMessage.includes(word)
 		|| finalMessage.includes(word) || finalMessagenoSpaces.includes(word)) {
 			msg.delete();
 
-			return msg.author.send(`Your message contains the restricted word "${word}". Please refrain from using restricted words again.\n\nOriginal message:\n${msg.content}`)
+			return msg.author.send(`Your message contains the restricted word "${word}". Please refrain from using restricted words again.
+
+Original message:
+${normalizedMessage}`)
 				.catch(() => msg.channel.send(`${msg.member}, you used a restricted word. Please refrain from doing so again.`));
 		}
 	}

--- a/src/pieces/blacklist.ts
+++ b/src/pieces/blacklist.ts
@@ -96,10 +96,8 @@ async function register(bot: Client): Promise<void> {
 
 async function filterMessages(msg: Message): Promise<Message | void> {
 	let normalizedMessage = msg.content.normalize('NFKD');
-	let attemptedBypass = false;
 	for (const [re, rep] of NORMALIZE) {
 		const cleanerString = normalizedMessage.replace(re, rep);
-		attemptedBypass = attemptedBypass || normalizedMessage !== cleanerString;
 		normalizedMessage = cleanerString;
 	}
 

--- a/src/pieces/blacklist.ts
+++ b/src/pieces/blacklist.ts
@@ -120,7 +120,7 @@ async function filterMessages(msg: Message): Promise<Message | void> {
 		|| finalMessage.includes(word) || finalMessagenoSpaces.includes(word)) {
 			msg.delete();
 
-			return msg.author.send(`You used a restricted word. Please refrain from doing so again.`)
+			return msg.author.send(`You used the restricted word "${word}". Please refrain from doing so again.`)
 				.catch(() => msg.channel.send(`${msg.member}, you used a restricted word. Please refrain from doing so again.`));
 		}
 	}


### PR DESCRIPTION
This change helps to identify false positives, as it will let you know what word it thought you used. Sometimes the swear filter produces false positives for 2 adjacent words that happen to spell out a swear word when spaces are removed. This will let you know what word it thought you used so that you can edit the message accordingly.